### PR TITLE
feat: Create Group Layer activity

### DIFF
--- a/src/activities/CreateGroupLayer.ts
+++ b/src/activities/CreateGroupLayer.ts
@@ -7,15 +7,14 @@ import { activate } from "@vertigis/workflow/Hooks";
 
 interface CreateGroupLayerInputs {
     /**
-     * @description The name of the group layer to create.
-     * @required
+     * @description The title of the group layer to create.
      */
-    name: string;
+    title?: string;
 
     /**
-     * @description The collection of layers to be added as child elements.
+     * @description Any of the layer's properties for constructing the layer instance (e.g. blendMode, opacity, etc.).
      */
-    layers?: __esri.Layer[];
+    properties?: __esri.GroupLayerProperties;
 }
 
 interface CreateGroupLayerOutputs {
@@ -36,10 +35,7 @@ interface CreateGroupLayerOutputs {
 export default class CreateGroupLayer implements IActivityHandler {
     
     async execute(inputs: CreateGroupLayerInputs, context: IActivityContext, type: typeof MapProvider): Promise<CreateGroupLayerOutputs> {
-        const { name, layers } = inputs;
-        if (!name) {
-            throw new Error("name is required");
-        }
+        const { properties, title } = inputs;
         
         const mapProvider = type.create();
         await mapProvider.load();
@@ -49,7 +45,7 @@ export default class CreateGroupLayer implements IActivityHandler {
             throw new Error("map is required");
         }
 
-        const layer = new GroupLayer({ title: name, layers: layers || [] });  
+        const layer = new GroupLayer({ title, ...properties });  
         map.add(layer);
 
         return { result: layer };

--- a/src/activities/CreateGroupLayer.ts
+++ b/src/activities/CreateGroupLayer.ts
@@ -11,6 +11,11 @@ interface CreateGroupLayerInputs {
      * @required
      */
     name?: string;
+
+    /**
+     * @description The collection of layers to be added as child elements.
+     */
+    layers?: __esri.Layer[];
 }
 
 interface CreateGroupLayerOutputs {
@@ -25,12 +30,13 @@ interface CreateGroupLayerOutputs {
  * @category ArcGIS Maps SDK for JavaScript
  * @helpUrl https://developers.arcgis.com/javascript/latest/api-reference/esri-layers-GroupLayer.html
  * @description Creates a new group layer item
+ * @supportedApps EXB, GWV
  */
 @activate(MapProvider)
 export default class CreateGroupLayer implements IActivityHandler {
     
     async execute(inputs: CreateGroupLayerInputs, context: IActivityContext, type: typeof MapProvider): Promise<CreateGroupLayerOutputs> {
-        const { name } = inputs;
+        const { name, layers } = inputs;
         if (!name) {
             throw new Error("name is required");
         }
@@ -43,7 +49,7 @@ export default class CreateGroupLayer implements IActivityHandler {
             throw new Error("map is required");
         }
 
-        const layer = new GroupLayer({ title: name });  
+        const layer = new GroupLayer({ title: name, layers: layers || [] });  
         map.add(layer);
 
         return { result: layer };

--- a/src/activities/CreateGroupLayer.ts
+++ b/src/activities/CreateGroupLayer.ts
@@ -1,9 +1,5 @@
 import type { IActivityHandler } from "@vertigis/workflow";
-import { MapProvider } from "@vertigis/workflow/activities/arcgis/MapProvider";
-import type { IActivityContext } from "@vertigis/workflow/IActivityHandler";
-import WebMap from "@arcgis/core/WebMap";
 import GroupLayer from "@arcgis/core/layers/GroupLayer";
-import { activate } from "@vertigis/workflow/Hooks";
 
 interface CreateGroupLayerInputs {
     /**
@@ -32,8 +28,7 @@ interface CreateGroupLayerOutputs {
  * @supportedApps EXB, GWV
  */
 export default class CreateGroupLayer implements IActivityHandler {
-    
-    async execute(inputs: CreateGroupLayerInputs): Promise<CreateGroupLayerOutputs> {
+    execute(inputs: CreateGroupLayerInputs): CreateGroupLayerOutputs {
         const { properties, title } = inputs;
         const layer = new GroupLayer({ title, ...properties });  
 

--- a/src/activities/CreateGroupLayer.ts
+++ b/src/activities/CreateGroupLayer.ts
@@ -31,22 +31,11 @@ interface CreateGroupLayerOutputs {
  * @description Creates a new group layer item
  * @supportedApps EXB, GWV
  */
-@activate(MapProvider)
 export default class CreateGroupLayer implements IActivityHandler {
     
-    async execute(inputs: CreateGroupLayerInputs, context: IActivityContext, type: typeof MapProvider): Promise<CreateGroupLayerOutputs> {
+    async execute(inputs: CreateGroupLayerInputs): Promise<CreateGroupLayerOutputs> {
         const { properties, title } = inputs;
-        
-        const mapProvider = type.create();
-        await mapProvider.load();
-
-        const map = mapProvider.map as WebMap;
-        if (!map) {
-            throw new Error("map is required");
-        }
-
         const layer = new GroupLayer({ title, ...properties });  
-        map.add(layer);
 
         return { result: layer };
     }

--- a/src/activities/CreateGroupLayer.ts
+++ b/src/activities/CreateGroupLayer.ts
@@ -10,7 +10,7 @@ interface CreateGroupLayerInputs {
      * @description The name of the group layer to create.
      * @required
      */
-    name?: string;
+    name: string;
 
     /**
      * @description The collection of layers to be added as child elements.

--- a/src/activities/CreateGroupLayer.ts
+++ b/src/activities/CreateGroupLayer.ts
@@ -1,0 +1,51 @@
+import type { IActivityHandler } from "@vertigis/workflow";
+import { MapProvider } from "@vertigis/workflow/activities/arcgis/MapProvider";
+import type { IActivityContext } from "@vertigis/workflow/IActivityHandler";
+import WebMap from "@arcgis/core/WebMap";
+import GroupLayer from "@arcgis/core/layers/GroupLayer";
+import { activate } from "@vertigis/workflow/Hooks";
+
+interface CreateGroupLayerInputs {
+    /**
+     * @description The name of the group layer to create.
+     * @required
+     */
+    name?: string;
+}
+
+interface CreateGroupLayerOutputs {
+    /**
+     * @description The new Group Layer.
+     */
+    result: __esri.GroupLayer;
+}
+
+/**
+ * @clientOnly
+ * @category ArcGIS Maps SDK for JavaScript
+ * @helpUrl https://developers.arcgis.com/javascript/latest/api-reference/esri-layers-GroupLayer.html
+ * @description Creates a new group layer item
+ */
+@activate(MapProvider)
+export default class CreateGroupLayer implements IActivityHandler {
+    
+    async execute(inputs: CreateGroupLayerInputs, context: IActivityContext, type: typeof MapProvider): Promise<CreateGroupLayerOutputs> {
+        const { name } = inputs;
+        if (!name) {
+            throw new Error("name is required");
+        }
+        
+        const mapProvider = type.create();
+        await mapProvider.load();
+
+        const map = mapProvider.map as WebMap;
+        if (!map) {
+            throw new Error("map is required");
+        }
+
+        const layer = new GroupLayer({ title: name });  
+        map.add(layer);
+
+        return { result: layer };
+    }
+}

--- a/src/index.ts
+++ b/src/index.ts
@@ -4,6 +4,7 @@ export { default as CreateAreaMeasurement2D } from "./activities/CreateAreaMeasu
 export { default as CreateAreaMeasurement3D } from "./activities/CreateAreaMeasurement3D";
 export { default as CreateDirectLineMeasurement3D } from "./activities/CreateDirectLineMeasurement3D";
 export { default as CreateDistanceMeasurement2D } from "./activities/CreateDistanceMeasurement2D";
+export { default as CreateGroupLayer } from "./activities/CreateGroupLayer";
 export { default as CreateLayerFromArcGisServerUrl } from "./activities/CreateLayerFromArcGisServerUrl";
 export { default as CreateLayerFromPortalItem } from "./activities/CreateLayerFromPortalItem";
 export { default as CreateMediaLayer } from "./activities/CreateMediaLayer";


### PR DESCRIPTION
New activity Create Group Layer. Currently expects a name and returns the GroupLayer object for later reuse.
Currently no Wf activity accepts a parent layer as input parameter.

Questions:
- passing a [number] index parameter as well?
- forcing the creation if GL with name already exists?
- returning GroupLayer or __esri.GroupLayer, what is the difference?